### PR TITLE
Update Rendite_Code_für_Notebook

### DIFF
--- a/Rendite_Code_für_Notebook
+++ b/Rendite_Code_für_Notebook
@@ -59,6 +59,8 @@ def f(Interest_on_invest,Start_capital,Monthly_invest,years_til_payout,inflation
     k=Start_capital*1
     kkk=Start_capital*1
     pure=Start_capital*1
+    vorabpauschale=0.02*.7
+    vorabsteuer=0
     i=0
     ii=[]
     A_0=Monthly_invest*12
@@ -69,6 +71,7 @@ def f(Interest_on_invest,Start_capital,Monthly_invest,years_til_payout,inflation
         if i<einzahlungsstopp:
             k=(k*(P_k-inflation)+A_0*((P_k-inflation-1)/2+1))
             pure=(pure+A_0)*(1-inflation)
+            vorabsteuer=vorabsteuer+(k-pure)*vorabpauschale
         else:
             k=(k*(P_k-inflation))
 
@@ -95,7 +98,7 @@ def f(Interest_on_invest,Start_capital,Monthly_invest,years_til_payout,inflation
     ax.set_ylim(-10000, max(kk)+20000)
     plt.grid()
     plt.plot([year_adjusted[0],max(year_adjusted)],[0,0],c="black",linewidth=2)
-    plt.title("Monthly 3% payout after "+str(round(years_til_payout,1))+" years after tax inflationsbereinigt:"+str(round(((payout_start*(payoutrate))*0.818/12*(1+pure/payout_start)))))
+    plt.title("Monthly payout after "+str(round(years_til_payout,1))+" yrs after tax inflationsbereinigt:"+str(round(((payout_start*(payoutrate))*0.818/12*(1+pure/payout_start))))+",vorabsteuer bezahlt 2% p.a. :"+str(round(((payout_start*(payoutrate))*0.818/12*(1+pure/payout_start)*(1+vorabsteuer/payout_start)))))
     plt.legend()
     plt.show()
 


### PR DESCRIPTION
Zweite Zahl gibt Auszahlung unter Betrachtung der Vorabpauschale von 2% p.a. an.  Zwei Zahlen für monatliches Geld nach Steuer und inflation sind daher nun sichtbar (ohne und mit Vorabpauschale).